### PR TITLE
Feat: 매니저 메인페이지

### DIFF
--- a/src/apis/getSch.ts
+++ b/src/apis/getSch.ts
@@ -1,18 +1,27 @@
 import instance from 'apis/instance';
 
-export const getMonthly = async (year: number, month: number) => {
-  const response = await instance.post(`/scheduler/home`, {
+export const getMonthly = async (year: number, month: number, memberId: number) => {
+  const response = await instance.post(`/schedule/monthly`, {
+    memberId: memberId,
     month: month,
     year: year,
   });
-  return await nowMonthDate(month, year, response.data.response.schedule);
+  return await nowMonthDate(year, month, response.data.schedule);
+};
+
+export const getDaily = async (year: number, month: number, date: number) => {
+  return await instance.post(`/schedule/daily`, {
+    date: date,
+    month: month,
+    year: year,
+  });
 };
 
 // 받은 객체를 3차원 배열로
 const nowMonthDate = (year: number, month: number, data: any) => {
   const firstDay = new Date(year, month, 1).getDay();
   const lastDate = new Date(year, month + 1, 0).getDate();
-
+  console.log(year, month, 1, firstDay);
   const dates = [];
   // 저번달 끝부분
   for (let i = -firstDay + 1; i <= 0; i++) {

--- a/src/apis/manageGroup.ts
+++ b/src/apis/manageGroup.ts
@@ -7,7 +7,7 @@ interface MarketInfo {
   detailAddress: string;
 }
 
-const addNewGroup = async ({ marketName, marketNumber, mainAddress, detailAddress }: MarketInfo) => {
+export const addNewGroup = async ({ marketName, marketNumber, mainAddress, detailAddress }: MarketInfo) => {
   return await instance.post(`/group`, {
     marketName: marketName,
     marketNumber: marketNumber,
@@ -16,4 +16,6 @@ const addNewGroup = async ({ marketName, marketNumber, mainAddress, detailAddres
   });
 };
 
-export { addNewGroup };
+export const getGroupMemberList = async () => {
+  return await instance.get(`/group`);
+};

--- a/src/components/@commons/SubmitButton.tsx
+++ b/src/components/@commons/SubmitButton.tsx
@@ -6,6 +6,7 @@ const SubmitButton = styled.button<{
   $disabledColor?: string;
   $disabled?: boolean;
   $width?: string;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }>`
   display: flex;
   flex-direction: row;

--- a/src/components/@commons/calendar/Calendar.tsx
+++ b/src/components/@commons/calendar/Calendar.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import FlexContainer from '../FlexContainer';
 import PageContainer from '../PageContainer';
 import styled from 'styled-components';
-import { getMonthly } from 'apis/getSch';
+import { getDaily, getMonthly } from 'apis/getSch';
 import { useQuery } from '@tanstack/react-query';
 
 const Calendar = (): JSX.Element => {
@@ -10,7 +10,7 @@ const Calendar = (): JSX.Element => {
   const year = today.getFullYear();
   const month = today.getMonth() + 1;
 
-  const { data: obj, isFetching } = useQuery(['getMonthly', month, year], () => getMonthly(year, month));
+  const { data: obj, isFetching } = useQuery(['getMonthly', month, year], () => getMonthly(year, month, 1));
 
   return (
     <PageContainer justify="start">
@@ -20,7 +20,7 @@ const Calendar = (): JSX.Element => {
           {obj.map((weekArray, i) => (
             <WeekBox $wFull key={`${i}주`}>
               {weekArray.map((e) => (
-                <DayBox key={e.date} date={new Date(year, month, e.date).getDate()} timeList={e.timeList}></DayBox>
+                <DayBox key={e.date} dateObject={new Date(year, month, e.date)} timeList={e.timeList}></DayBox>
               ))}
             </WeekBox>
           ))}
@@ -32,10 +32,10 @@ const Calendar = (): JSX.Element => {
 
 export default Calendar;
 
-const DayBox = ({ date, timeList }: DayProps): JSX.Element => {
+const DayBox = ({ dateObject, timeList }: DayProps): JSX.Element => {
   return (
-    <StyeldDayBox>
-      <BadgeCont>{date}</BadgeCont>
+    <StyeldDayBox onClick={() => getDaily(dateObject.getFullYear(), dateObject.getMonth(), dateObject.getDate())}>
+      <BadgeCont>{dateObject.getDate()}</BadgeCont>
       {!!timeList && (
         <BadgeCont>
           {timeList.map((t) => (
@@ -50,7 +50,7 @@ const DayBox = ({ date, timeList }: DayProps): JSX.Element => {
 };
 
 interface DayProps {
-  date: number;
+  dateObject: Date;
   timeList: string[];
   children?: any;
 }

--- a/src/components/OnBoardingSection.tsx
+++ b/src/components/OnBoardingSection.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import LoginOrSignup from 'components/@commons/LoginOrSignup';
+import FlexContainer from 'components/@commons/FlexContainer';
+
+const OnBoardingSection = (): JSX.Element => {
+  return (
+    <FlexContainer $wFull>
+      <div className="w-full bg-slate-400 h-80 mb-8">임시 온보딩 컴포넌트</div>
+      <LoginOrSignup />
+    </FlexContainer>
+  );
+};
+
+export default OnBoardingSection;

--- a/src/components/admin-addGroup/AddGroup.tsx
+++ b/src/components/admin-addGroup/AddGroup.tsx
@@ -6,10 +6,6 @@ import useForm from 'hooks/useForm';
 import React from 'react';
 import styled from 'styled-components';
 
-interface Props {
-  doneStateHandler: () => void;
-}
-
 const AddGroup = ({ doneStateHandler }: Props): JSX.Element => {
   interface MarketInfo {
     marketName: string;
@@ -40,10 +36,10 @@ const AddGroup = ({ doneStateHandler }: Props): JSX.Element => {
       <span className="text-center text-xl font-bold">그룹 생성</span>
       <GradationBox width="100%">
         <FlexContainer $gap="0">
-          <InputGroup id="marketName" onChange={formHandler} labelName="상호명" />
-          <InputGroup id="marketNumber" onChange={formHandler} labelName="사업자 번호" />
-          <InputGroup id="mainAddress" onChange={formHandler} labelName="주소1" />
-          <InputGroup id="detailAddress" onChange={formHandler} labelName="주소2" />
+          <InputBar id="marketName" onChange={formHandler} labelName="상호명" />
+          <InputBar id="marketNumber" onChange={formHandler} labelName="사업자 번호" />
+          <InputBar id="mainAddress" onChange={formHandler} labelName="주소1" />
+          <InputBar id="detailAddress" onChange={formHandler} labelName="주소2" />
         </FlexContainer>
       </GradationBox>
       <SubmitButton onClick={submitHandler}>그룹 생성하기</SubmitButton>
@@ -53,7 +49,7 @@ const AddGroup = ({ doneStateHandler }: Props): JSX.Element => {
 
 export default AddGroup;
 
-const InputGroup = ({ onChange, id, labelName }: InputProps): JSX.Element => {
+const InputBar = ({ onChange, id, labelName }: InputProps): JSX.Element => {
   return (
     <InputBox $direction="row" $padding="0">
       <Label htmlFor={id}>{labelName}</Label>
@@ -61,6 +57,10 @@ const InputGroup = ({ onChange, id, labelName }: InputProps): JSX.Element => {
     </InputBox>
   );
 };
+
+interface Props {
+  doneStateHandler: () => void;
+}
 
 interface InputProps {
   onChange: any;

--- a/src/components/admin-home/AdminHomeSection.tsx
+++ b/src/components/admin-home/AdminHomeSection.tsx
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { getGroupMemberList } from 'apis/manageGroup';
+import FlexContainer from 'components/@commons/FlexContainer';
+import Calendar from 'components/@commons/calendar/Calendar';
+import React from 'react';
+
+const AdminHomeSection = (): JSX.Element => {
+  const { data: obj } = useQuery(['getGroupMembers'], getGroupMemberList);
+
+  return (
+    <FlexContainer>
+      {obj?.data.members.length > 0 ? <Calendar /> : <div>그룹에 직원이 없습니다 초대하기 버튼</div>}
+    </FlexContainer>
+  );
+};
+
+export default AdminHomeSection;

--- a/src/components/admin-home/NoGroupSection.tsx
+++ b/src/components/admin-home/NoGroupSection.tsx
@@ -1,0 +1,18 @@
+import { convertPath } from 'apis/convertURI';
+import FlexContainer from 'components/@commons/FlexContainer';
+import SubmitButton from 'components/@commons/SubmitButton';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const NoGroupSection = (): JSX.Element => {
+  const navigate = useNavigate();
+
+  return (
+    <FlexContainer $wFull $align="center">
+      <span>그룹을 생성하세요</span>
+      <SubmitButton onClick={() => navigate(convertPath('/addGroup'))}>그룹 생성하기</SubmitButton>
+    </FlexContainer>
+  );
+};
+
+export default NoGroupSection;

--- a/src/components/alba-invited/InvitationSection.tsx
+++ b/src/components/alba-invited/InvitationSection.tsx
@@ -14,7 +14,7 @@ interface Props {
   afterJoinHandler: any;
 }
 
-const InvitationTemplate = ({ invitationKey, afterJoinHandler }: Props): JSX.Element => {
+const InvitationSection = ({ invitationKey, afterJoinHandler }: Props): JSX.Element => {
   const loginState = useSelector((state: RootState) => state.login);
 
   const { modalOnHandler, modalOffHandler, ModalComponent } = useModal();
@@ -58,4 +58,4 @@ const InvitationTemplate = ({ invitationKey, afterJoinHandler }: Props): JSX.Ele
   );
 };
 
-export default InvitationTemplate;
+export default InvitationSection;

--- a/src/pages/InvitedPage.tsx
+++ b/src/pages/InvitedPage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import PageContainer from 'components/@commons/PageContainer';
 import JoinDone from 'components/alba-invited/JoinDone';
-import InvitationTemplate from 'components/alba-invited/InvitationTemplate';
+import InvitationSection from 'components/alba-invited/InvitationSection';
 
 const InvitedPage = (): JSX.Element => {
   // 로그인상태인 유저가 이미 그룹에 소속된 경우 : 리다이렉트 "/" 또는 에러페이지
@@ -17,7 +17,7 @@ const InvitedPage = (): JSX.Element => {
       {isDone ? (
         <JoinDone />
       ) : (
-        <InvitationTemplate invitationKey={invitationKey} afterJoinHandler={() => setisDone((prev) => true)} />
+        <InvitationSection invitationKey={invitationKey} afterJoinHandler={() => setisDone((prev) => true)} />
       )}
     </PageContainer>
   );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,22 +1,20 @@
 import PageContainer from 'components/@commons/PageContainer';
-import LoginOrSignup from 'components/@commons/LoginOrSignup';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from 'states/store';
 
+import NoGroupSection from 'components/admin-home/NoGroupSection';
+import AdminHomeSection from 'components/admin-home/AdminHomeSection';
+import OnBoardingSection from 'components/OnBoardingSection';
+
 const MainPage = (): JSX.Element => {
   const loginState = useSelector((state: RootState) => state.login);
+  const isLogin: boolean = loginState.islogin;
+  const isGroup: boolean = loginState.userData?.groupId !== 0;
 
   return (
-    <PageContainer withoutHeader={!loginState.islogin} withoutBottonBar={loginState.userData?.groupId === 0}>
-      {loginState.islogin ? (
-        '로그인됨'
-      ) : (
-        <>
-          <div className="w-full bg-slate-400 h-80 mb-8">임시 온보딩 컴포넌트</div>
-          <LoginOrSignup />
-        </>
-      )}
+    <PageContainer withoutHeader={!isLogin} withoutBottonBar={!isGroup}>
+      {isLogin ? isGroup ? <AdminHomeSection /> : <NoGroupSection /> : <OnBoardingSection />}
     </PageContainer>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -5,11 +5,11 @@ import { useSelector } from 'react-redux';
 import { RootState } from 'states/store';
 
 const MainPage = (): JSX.Element => {
-  const islogin = useSelector((state: RootState) => state.login).islogin;
+  const loginState = useSelector((state: RootState) => state.login);
 
   return (
-    <PageContainer withoutHeader={!islogin} withoutBottonBar>
-      {islogin ? (
+    <PageContainer withoutHeader={!loginState.islogin} withoutBottonBar={loginState.userData?.groupId === 0}>
+      {loginState.islogin ? (
         '로그인됨'
       ) : (
         <>


### PR DESCRIPTION
- 매니저 메인 페이지를 상태에 따라 3가지로 구분 
  - 비로그인 / 로그인(그룹있음) / 로그인(그룹없음)
- 매니저 메인 페이지 (로그인-그룹있음) 에 캘린더 컴포넌트 등록
- 일별 스케줄 요청 함수 추가
- 캘린더에서 일 클릭시 일별 스케줄 요청 함수 실행
- 월별 스케줄 요청 함수 requestBody 에  memberId 추가
- 그룹 멤버 불러오기 요청 함수 추가